### PR TITLE
Unicode/Utf8 filenames

### DIFF
--- a/src/tag.cc
+++ b/src/tag.cc
@@ -104,7 +104,7 @@ Handle<Value> Tag::New(const Arguments &args) {
     if (args.Length() < 1 || !args[0]->IsString())
         return ThrowException(String::New("Expected string 'path' as first argument"));
 
-    String::AsciiValue path(args[0]->ToString());
+    String::Utf8Value path(args[0]->ToString());
 
     TagLib::FileRef * f = new TagLib::FileRef(*path);
     if ( f->isNull() || !f->tag() )


### PR DESCRIPTION
Support utf8value file names which is also compatible with ascii.

Fixed:

```
sagan dekz$ node node_modules/taglib/examples/simple.js ~/Projects/node-taglib/examples/ここには何もかもがあるし、何もかもがない.mp3 
TagLib: Could not open file /Users/dekz/Projects/node-taglib/examples/SSkoU?K?K?B?WU?K?K?jD.mp3

node.js:189
        throw e; // process.nextTick error, or 'error' event on first tick
        ^
Error while reading data from /Users/dekz/Projects/node-taglib/examples/SSkoU?K?K?B?WU?K?K?jD.mp3
```

Reading in the data is fine though:

```
DEBUG: { genre: '',
  artist: 'Toe',
  album: 'For Long Tomorrow',
  year: 2009,
  title: 'ここには何もかもがあるし、何もかもがない',
  track: 1 }
```
