### PR TITLE
Fix compilation bug (Loop())

### DIFF
--- a/src/tag.cc
+++ b/src/tag.cc
@@ -236,7 +236,7 @@ v8::Handle<v8::Value> Tag::AsyncTag(const v8::Arguments &args) {
     baton->callback = Persistent<Function>::New(callback);
     baton->error = 0;
 
-    uv_queue_work(Loop(), &baton->request, Tag::AsyncTagRead, Tag::AsyncTagReadAfter);
+    uv_queue_work(uv_default_loop(), &baton->request, Tag::AsyncTagRead, Tag::AsyncTagReadAfter);
 
     return Undefined();
 }


### PR DESCRIPTION
Use `uv_default_loop()` in `tag.cc` instead of the (undeclared?) `Loop()`.

In case this isn't what you wanted, or you have some uncommitted code in your working copy, please regard this pull request as obsolete! 
