### PR TITLE
Fix linker error (on Mac OS 10.5.8)

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -11,6 +11,9 @@
           'xcode_settings': {
             'OTHER_CFLAGS': [
               '<!@(taglib-config --cflags)'
+            ],
+            'OTHER_LDFLAGS': [
+              '-dynamiclib'
             ]
           }
         }, {


### PR DESCRIPTION
I've been getting the following linker error when trying to npm install node-taglib :

i686-apple-darwin9-g++-4.0.1: -install_name only allowed with -dynamiclib

I finally tracked down the code in node-gyp that was generating the linker arguments in the makefiles, and it looks like it just needed augmenting with a -dynamiclib in the LDFLAGS.
