### PR TITLE
Remove -dynamiclib flag

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -11,9 +11,6 @@
           'xcode_settings': {
             'OTHER_CFLAGS': [
               '<!@(taglib-config --cflags)'
-            ],
-            'OTHER_LDFLAGS': [
-              '-dynamiclib'
             ]
           }
         }, {


### PR DESCRIPTION
Introduced in #37 as a cosmetic improvement for some specific systems, the dynamiclib flag results in the following error on Mac OS 10.9.2:

```
clang: error: invalid argument '-bundle' not allowed with '-dynamiclib'
```

Removing it resolves the error.
